### PR TITLE
Add link to the Markdown Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Markdown is a markup language created by John Gruber in collaboration with Aaron
 - [Interactive Markdown Tutorial](http://www.markdowntutorial.com/)
 - [GitHub's Mastering Markdown](https://guides.github.com/features/mastering-markdown/)
 - [Markdown Cheatsheet](https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet) :gem: _Where to look when you don't remember the syntax!_
+- [Markdown Guide](https://www.markdownguide.org) - A concise, barebones guide to Markdown. 
 
 ---
 


### PR DESCRIPTION
I'd like to suggest adding a link to the [Markdown Guide](https://www.markdownguide.org/). This is a new [open source](https://github.com/mattcone/markdown-guide) project that is still actively being worked on, but it's complete enough to be useful.

Disclosure: This is my personal website. 