### PR TITLE
Add Mark Text

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ _Please read the [contribution guidelines](contributing.md) before contributing.
 - [iA Writer](https://ia.net/writer/) - iA Writer is designed to provide the best writing experience on Mac OS, iOS and Android. :gem: _Really simple editor!_ ![Android OS][android-os] ![iOS Logo][ios-logo] ![Apple][apple]
 - [Markdownify](https://markdownify.js.org) - A minimal Markdown Editor desktop app. ![Apple][apple] ![Linux][linux] ![Windows 8][windows8]
 - [MarkRight](https://github.com/dvcrn/markright) - Minimalistic github flavored Markdown editor. ![Apple][apple] ![Linux][linux] ![Windows 8][windows8]
+- [Mark Text](https://github.com/marktext/marktext/) - Next generation Markdown editor (built with Electron). ![Apple][apple] ![Linux][linux] ![Windows 8][windows8]
 - [PileMd](https://pilemd.com/) - Markdown Note App. ![Apple][apple] ![Linux][linux] ![Windows 8][windows8]
 - [StackEdit](https://stackedit.io/) - In-browser markdown editor. ![Globe][globe]
 - [TOAST UI Editor](https://nhnent.github.io/tui.editor/) - Extensible GFM Markdown WYSIWYG Editor ![Globe][globe]


### PR DESCRIPTION
## Project URL
[https://github.com/marktext/marktext](https://github.com/marktext/marktext)

## Category
Tools > Editors

## Description
Add the open source Markdown editor [Mark Text](https://github.com/marktext/marktext) to the list of Markdown editors.
 
## Why it should be included to `awesome-markdown`
Mark Text describes itself as the "next generation Markdown editor". It is built with Electron, and provides some nice features despite being in heavy development. It is also quite popular in the open source community.

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in alphabetical order
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

