### PR TITLE
Add `remark-lint` to list of linters

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ _Please read the [contribution guidelines](contributing.md) before contributing.
 
 - [Markdown Lint Tool](https://github.com/markdownlint/markdownlint) - Tool to check Markdown files and flag style issues.
 - [Markdownlint](https://github.com/igorshubovych/markdownlint-cli) - Node.js style checker and lint tool for Markdown/CommonMark files.
+- [remark-lint](https://github.com/remarkjs/remark-lint) - Markdown code style linter.
 - [textlint](https://textlint.github.io/) - Pluggable linting tool for text and markdown.
 
 ### Miscellaneous


### PR DESCRIPTION
This adds [remark-lint](https://github.com/remarkjs/remark-lint) to the list of linters.

## Project URL

https://github.com/remarkjs/remark-lint

## Category

Linters

## Description

Markdown code style linter
 
## Why it should be included to `awesome-markdown` (optional)

It’s used in this project, so I’m sure it should be on the list as well 😉

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in alphabetical order
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English