### PR TITLE
Add cmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ _Please read the [contribution guidelines](.github/contributing.md) before contr
 
 ### C
 
+- [cmark](https://github.com/commonmark/cmark) - CommonMark parsing and rendering library and program in C.
 - [Hoedown](https://github.com/hoedown/hoedown) - Standards compliant, fast, secure Markdown processing library in C (Sundown fork).
 - [peg-markdown](https://github.com/jgm/peg-markdown) - An implementation of Markdown in C, using a PEG grammar.
 - [Sundown](https://github.com/vmg/sundown) - Standards compliant, fast, secure Markdown processing library in C.


### PR DESCRIPTION
## Project URL
https://github.com/commonmark/cmark

## Category
Libraries > C

## Description
Add cmark, a C reference library to parse and render CommonMark.
 
## Why it should be included to `awesome-markdown` (optional)
This library is actively maintained and seems to serve as a reference implementation of CommonMark parsing.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in alphabetical order
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

