### PR TITLE
Add PyMdown Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ _Please read the [contribution guidelines](.github/contributing.md) before contr
 - [markdown-it-py](https://github.com/executablebooks/markdown-it-py) - Markdown parser, done right. 100% CommonMark support, extensions, syntax plugins & high speed. Now in Python!
 - [markdown2](https://github.com/trentm/python-markdown2) - Fast and complete implementation of Markdown in Python.
 - [Mistune](https://github.com/lepture/mistune) - The fastest Markdown parser in pure Python with renderer feature.
+- [PyMdown Extensions](https://facelessuser.github.io/pymdown-extensions/) - A collection of extensions for Python Markdown.
 - [Python-Markdown](https://github.com/Python-Markdown/markdown) - Python implementation of John Gruber's Markdown.
 
 ### Ruby


### PR DESCRIPTION
Add PyMdown Extensions.

## Project URL
https://facelessuser.github.io/pymdown-extensions/

## Category
Libraries > Python

## Description
PyMdown Extensions is an extensive set of extensions for the default Python Markdown rendering engine.

## Why it should be included to `awesome-markdown` (optional)
This collection is popular in the Python ecosystem and is actively and well maintained (you can tell by the clean and precise documentation).

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [x] Addition in alphabetical order
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

