### PR TITLE
laravel-commonmark-blog

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ _Please read the [contribution guidelines](.github/contributing.md) before contr
 - [Pelican](https://blog.getpelican.com/) - Static site generator that requires no database or server-side logic.
 - [Svbtle](https://svbtle.com/) - Blogging platform designed to help you think.
 - [Vuepress](https://vuepress.vuejs.org/) - Minimalistic Vue-powered static site generator.
+- [Laravel CommonMark Blog](https://github.com/spekulatius/laravel-commonmark-blog) - Static-generator to use with Laravel. Utilizes CommonMark and FrontMatter and publishes directly into the `public`-folder.
 
 ## Libraries
 


### PR DESCRIPTION
Hey @BubuAnabelas,

I've built a static generator using the markdown-variant commonmark for Laravel. Please find below the details as requested.

Cheers,
Peter

## Project URL
https://github.com/spekulatius/laravel-commonmark-blog

## Category
Blog

## Description
Generates static pages from CommonMark/FrontMatter and publishes them in the public-directory. Utilizes existing Laravel dependencies. Works for blogs, help sections, etc.
 
## Why it should be included to `awesome-markdown` (optional)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] Only one project/change is in this pull request
- [ ] Addition in alphabetical order
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

