### PR TITLE
Add editor components section

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ _Please read the [contribution guidelines](.github/contributing.md) before contr
 - [Mark Text](https://github.com/marktext/marktext/) - Next generation Markdown editor (built with Electron). ![Mac OS X][macosx] ![Linux][linux] ![Windows][windows]
 - [PileMd](https://pilemd.com/) - Markdown Note App. ![Mac OS X][macosx] ![Linux][linux] ![Windows][windows]
 - [StackEdit](https://stackedit.io/) - In-browser markdown editor. ![Globe][globe]
-- [TOAST UI Editor](https://ui.toast.com/tui-editor/) - Extensible GFM Markdown WYSIWYG Editor ![Globe][globe]
 - [Typora](https://typora.io/) - A minimal Markdown editor. ![Mac OS X][macosx] ![Linux][linux] ![Windows][windows]
 - [Notable](https://notable.md/) - The Markdown-based note-taking app that doesn't suck. ![Mac OS X][macosx] ![Linux][linux] ![Windows][windows]
 - [Boostnote](https://boostnote.io/) - A markdown editor for developers. ![Mac OS X][macosx] ![Linux][linux] ![Windows][windows]
@@ -159,6 +158,13 @@ _Please read the [contribution guidelines](.github/contributing.md) before contr
 - [Bear](https://bear.app/) - A beautiful, flexible writing app for crafting notes and prose. ![Mac OS X][macosx] ![iOS Logo][ios-logo]
 - [Obsidian](https://obsidian.md/) - Notebook editor with Mermaid support ![Mac OS X][macosx] ![Linux][linux] ![Windows][windows]
 - [Bangle.io](https://bangle.io/) - A Notion like note taking webapp where data is saved in Markdown format locally. ![Globe][globe]
+
+### Editor Components
+
+> Editor components for web apps to edit and save Markdown documents
+
+- [TOAST UI Editor](https://ui.toast.com/tui-editor/) - Extensible GFM Markdown Side-by-side Editor ![Globe][globe]
+- [Wysimark Editor](https://wysimark.com/) - WYSIWYG Markdown editor for React, Vue and JavaScript. CommonMark and GFM. With image uploads, attachments, and image resizing. MIT licensed. ![Globe][globe]
 
 ### Linters
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Project URL
https://www.wysimark.com/

## Category
Editor Components

## Description
I created a section for "Editor Components" because editor components to be integrated into a web app are quite different than editors that are to be used directly by end users to edit Markdown.

I moved Toast UI into that section as well as it is also an editor component and cannot be used to edit Markdown directly (must be integrated into a web app or website).
 
## Why it should be included to `awesome-markdown` (optional)

This is the first (that I'm aware of) pure WYSIWYG editor component that saves to Markdown. Most are side-by-side editors. It's backed by a web tools company (MeZine) that has been around for over 20 years. I'm the principle developer of Wysimark, and I'm the second biggest contributor to the Slate rich editor framework by commit which is the most popular React based rich text editor. It is a high quality component.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] Only one project/change is in this pull request
- [x] Addition in alphabetical order
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

I did make three changes, but this is because they are all related. (1) the addition of Wysimark (2) the creation of a "Editor Components" section and (3) moving Toast Editor into the category. In essence, all three changes are due to adding an "Editor Components" section and populating it. Hope this is okay. If not, I can make adjustments as per your request. Thanks.