### PR TITLE
add mdsf

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ _Please read the [contribution guidelines](.github/contributing.md) before contr
 
 - [Markdown Lint Tool](https://github.com/markdownlint/markdownlint) - Tool to check Markdown files and flag style issues.
 - [Markdownlint](https://github.com/igorshubovych/markdownlint-cli) - Node.js style checker and lint tool for Markdown/CommonMark files.
+- [mdsf](https://github.com/hougesen/mdsf) - Format markdown code blocks using your favorite code formatters.
 - [remark-lint](https://github.com/remarkjs/remark-lint) - Markdown code style linter.
 - [textlint](https://textlint.github.io/) - Pluggable linting tool for text and markdown.
 - [markdownlint](https://github.com/DavidAnson/vscode-markdownlint) - Markdown linting and style checking for Visual Studio Code.


### PR DESCRIPTION
## Project URL
[https://github.com/hougesen/mdsf](https://github.com/hougesen/mdsf)

## Category
Linter / formatter

## Description
Added mdsf, a tool for formatting markdown code blocks using "ordinary" code formatters that doesn't support it natively.

## Why it should be included to `awesome-markdown` (optional)

Manually formatting markdown codeblocks is very tedious.

## Checklist

- [x] Only one project/change is in this pull request
- [x] Addition in alphabetical order
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

