### PR TITLE
Add Reprose markdown editor for Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ _Please read the [contribution guidelines](.github/contributing.md) before contr
 - [Bear](https://bear.app/) - A beautiful, flexible writing app for crafting notes and prose. ![Mac OS X][macosx] ![iOS Logo][ios-logo]
 - [Obsidian](https://obsidian.md/) - Notebook editor with Mermaid support ![Mac OS X][macosx] ![Linux][linux] ![Windows][windows]
 - [Bangle.io](https://bangle.io/) - A Notion like note taking webapp where data is saved in Markdown format locally. ![Globe][globe]
+- [Reprose](https://reprose.pp.ua) - A Markdown editor for GitHub. It uses Github API for list, edit and save markdown files in repository. ![Globe][globe]
+
 
 ### Linters
 


### PR DESCRIPTION
Hello. I propose to add Reprpse – a Markdown editor for Github.

<!--- Provide a general summary of your changes in the Title above -->

## Project URL

https://reprose.pp.ua

## Category

Tools > Editors

## Description

I added a link to Reprose editor website.
 
## Why it should be included to `awesome-markdown` (optional)

## Checklist
- [x] Only one project/change is in this pull request
- [ ] Addition in alphabetical order
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English

