### PR TITLE
Add MDLook — portable offline Markdown editor for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ _Please read the [contribution guidelines](.github/contributing.md) before contr
 - [Obsidian](https://obsidian.md/) - Notebook editor with Mermaid support ![Mac OS X][macosx] ![Linux][linux] ![Windows][windows]
 - [Bangle.io](https://bangle.io/) - A Notion like note taking webapp where data is saved in Markdown format locally. ![Globe][globe]
 
+- [MDLook](https://github.com/r1qdj0/MDLook) - Portable, fully offline Markdown editor for Windows. No Electron, uses WebView2. \![Windows][windows]
+
 ### Linters
 
 > Flag and standarize your Markdown documents.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ _Please read the [contribution guidelines](.github/contributing.md) before contr
 - [Obsidian](https://obsidian.md/) - Notebook editor with Mermaid support ![Mac OS X][macosx] ![Linux][linux] ![Windows][windows]
 - [Bangle.io](https://bangle.io/) - A Notion like note taking webapp where data is saved in Markdown format locally. ![Globe][globe]
 
-- [MDLook](https://github.com/r1qdj0/MDLook) - Portable, fully offline Markdown editor for Windows. No Electron, uses WebView2. \![Windows][windows]
+- [MDLook](https://github.com/djosci/MDLook) - Portable, fully offline Markdown editor for Windows. No Electron, uses WebView2. \![Windows][windows]
 
 ### Linters
 


### PR DESCRIPTION
MDLook is a portable, fully offline Markdown editor for Windows that uses the system's WebView2 instead of bundling Electron.

- Website: https://mdlook.com
- GitHub: https://github.com/djosci/MDLook