### PR TITLE
Add markupmarkdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ _Please read the [contribution guidelines](.github/contributing.md) before contr
 - [markcat](https://github.com/BubuAnabelas/markcat) - Markdown files terminal viewer. :gem: _`cat` with Markdown highlight._ ![Mac OS X][macosx] ![Linux][linux] ![Windows][windows]
 - [Markdown Magic](https://github.com/DavidWells/markdown-magic) - Automatically format markdown files and sync external docs/src code
 - [Markdown Tables Generator](https://www.tablesgenerator.com/markdown_tables) - Visual Markdown table builder with CSV importing support. ![Globe][globe]
+- [markupmarkdown](https://github.com/jonradoff/markupmarkdown) - Google-Docs-style commenting on any Markdown file. Paste a GitHub URL or upload, drag-select text → leave a comment, get realtime threaded replies, @-mentions, and resolve. Includes an MCP server so AI agents join the same review loop as humans, plus AI revision via Anthropic Claude. ![Globe][globe]
 - [mdformat](https://github.com/executablebooks/mdformat) - CommonMark compliant Markdown formatter ![Mac OS X][macosx] ![Linux][linux] ![Windows][windows]
 - [remark](https://remark.js.org/) - Markdown processor powered by plugins
 - [Socrates](https://socrates.io/) - Serveless realtime Markdown editor and viewer, etherpad-like. ![Globe][globe]

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ _Please read the [contribution guidelines](.github/contributing.md) before contr
 - [markcat](https://github.com/BubuAnabelas/markcat) - Markdown files terminal viewer. :gem: _`cat` with Markdown highlight._ ![Mac OS X][macosx] ![Linux][linux] ![Windows][windows]
 - [Markdown Magic](https://github.com/DavidWells/markdown-magic) - Automatically format markdown files and sync external docs/src code
 - [Markdown Tables Generator](https://www.tablesgenerator.com/markdown_tables) - Visual Markdown table builder with CSV importing support. ![Globe][globe]
-- [markupmarkdown](https://github.com/jonradoff/markupmarkdown) - Google-Docs-style commenting on any Markdown file. Paste a GitHub URL or upload, drag-select text → leave a comment, get realtime threaded replies, @-mentions, and resolve. Includes an MCP server so AI agents join the same review loop as humans, plus AI revision via Anthropic Claude. ![Globe][globe]
+- [markupmarkdown](https://github.com/jonradoff/markupmarkdown) - "Google Docs for Markdown": collaborative editing and review for Markdown files. Anchored comment threads, suggested changes with one-click apply, review states, document checks, and GitHub round-trip (open any repo's `.md`, push edits back as a PR). Includes an MCP server so AI agents review alongside humans. ![Globe][globe]
 - [mdformat](https://github.com/executablebooks/mdformat) - CommonMark compliant Markdown formatter ![Mac OS X][macosx] ![Linux][linux] ![Windows][windows]
 - [remark](https://remark.js.org/) - Markdown processor powered by plugins
 - [Socrates](https://socrates.io/) - Serveless realtime Markdown editor and viewer, etherpad-like. ![Globe][globe]


### PR DESCRIPTION
Adds [markupmarkdown](https://github.com/jonradoff/markupmarkdown) to **Tools > Miscellaneous**.

## What it is

A Google-Docs-style commenting app for Markdown files. Paste a GitHub URL (or upload from disk), drag-select text to leave a comment, threaded replies + @-mentions, real-time sync via SSE, mark-as-done, and AI revision via Anthropic Claude. Bundles an MCP server so agents can join the same review loop as humans.

**Live demo:** <https://mumd.metavert.io/>

## Checklist

- [x] Search performed — no existing entry
- [x] Format matches the surrounding lines
- [x] Alphabetical position respected (between *Markdown Tables Generator* and *mdformat*)
- [x] HTTPS link
- [x] Capitalized, period-terminated description
- [x] One PR for one suggestion
- [x] Active OSS project (MIT)