### PR TITLE
Add Markdown Free to Tools → Converters

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ _Please read the [contribution guidelines](.github/contributing.md) before contr
 - [Dimer Markdown](https://github.com/dimerapp/markdown) - converts Markdown to HTML or to JSON ![Globe][globe] ![Mac OS X][macosx] ![Linux][linux] ![Windows][windows]
 - [HTML To Markdown for PHP](https://github.com/thephpleague/html-to-markdown) - Convert HTML to Markdown with PHP.
 - [markdown-pdf](https://github.com/alanshaw/markdown-pdf) - Markdown to PDF converter.
+- [Markdown Free](https://www.markdown.free) - Free in-browser converter for Markdown to PDF, DOCX, EPUB, HTML and TXT. No signup, no watermark, files never stored. [![Globe]][Globe]
 - [Markdown to PDF](https://www.markdowntopdf.com/) - Simple and useful website for converting Markdown to PDF. ![Globe][globe]
 - [Pandoc](https://pandoc.org/) - Universal document converter. ![Mac OS X][macosx] ![Linux][linux] ![Windows][windows]
 - [Torsimany](https://github.com/PolBaladas/torsimany) - Translate format-independent JSON to stylish, human-readable Markdown. ![Mac OS X][macosx] ![Linux][linux] ![Windows][windows]


### PR DESCRIPTION
## Project URL
https://www.markdown.free

## Category
Tools → Converters

## Description
Adds **Markdown Free**, a free in-browser Markdown converter, to the Converters
list (placed alphabetically under "M").

Entry being added:

    [Markdown Free](https://www.markdown.free) - Free in-browser converter for Markdown to PDF, DOCX, EPUB, HTML and TXT. No signup, no watermark, files never stored. [![Globe]][Globe]

Markdown Free lets you drag-and-drop or paste Markdown, preview it live, and
export to PDF, DOCX (Word), EPUB, HTML, or TXT. HTML/TXT conversion runs entirely
client-side and nothing is stored on a server. It supports GitHub Flavored
Markdown (tables, task lists, fenced code with syntax highlighting) and ships a
UI localized in 10 languages.

## Why it should be included to `awesome-markdown` (optional)
- Fills a gap in Converters: a **no-signup, privacy-first web converter** that
  outputs not only PDF but also DOCX, EPUB, HTML and TXT from a single interface.
- 100% free — no watermarks, no ads, no accounts; files are never persisted.
- Full GFM support with code syntax highlighting, plus a 10-locale UI.
- Open-source with a public, actively maintained repo (clear English README,
  recent commits).

## Checklist
- [x] Only one project/change is in this pull request
- [x] Addition in alphabetical order
- [x] Has a commit from less than 2 years ago
- [x] Has a **clear** README in English