### PR TITLE
Add PullMark

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ _Please read the [contribution guidelines](.github/contributing.md) before contr
 - [Bear](https://bear.app/) - A beautiful, flexible writing app for crafting notes and prose. ![Mac OS X][macosx] ![iOS Logo][ios-logo]
 - [Obsidian](https://obsidian.md/) - Notebook editor with Mermaid support ![Mac OS X][macosx] ![Linux][linux] ![Windows][windows]
 - [Bangle.io](https://bangle.io/) - A Notion like note taking webapp where data is saved in Markdown format locally. ![Globe][globe]
+- [PullMark](https://pullmark.app) - Native macOS Markdown reader and GitHub PR reviewer with rendered diffs, word-level highlights, and margin notes that coding agents can act on. ![Mac OS X][macosx]
 
 ### Linters
 

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ _Please read the [contribution guidelines](.github/contributing.md) before contr
 - [Bear](https://bear.app/) - A beautiful, flexible writing app for crafting notes and prose. ![Mac OS X][macosx] ![iOS Logo][ios-logo]
 - [Obsidian](https://obsidian.md/) - Notebook editor with Mermaid support ![Mac OS X][macosx] ![Linux][linux] ![Windows][windows]
 - [Bangle.io](https://bangle.io/) - A Notion like note taking webapp where data is saved in Markdown format locally. ![Globe][globe]
-- [PullMark](https://pullmark.app) - Native macOS Markdown reader and GitHub PR reviewer with rendered diffs, word-level highlights, and margin notes that coding agents can act on. ![Mac OS X][macosx]
+- [PullMark](https://pullmark.app) - Native macOS Markdown reader and GitHub PR reviewer with rendered diffs, word-level highlights, and margin notes that coding agents can act on. Localized in 8 languages. ![Mac OS X][macosx]
 
 ### Linters
 


### PR DESCRIPTION
Adds PullMark to Editors: a free, MIT-licensed native macOS app that renders local Markdown, reviews documentation-heavy GitHub PRs as rendered diffs, and stores review feedback as margin notes (HTML comments) inside the file, a documented format that coding agents can read and write.

Site: https://pullmark.app · Source: https://github.com/jedijashwa/pullmark